### PR TITLE
Fix for : plot title, x-title, y-title were not blank when dialog opened from the top level menu

### DIFF
--- a/barChart.js
+++ b/barChart.js
@@ -232,6 +232,47 @@ cat("Error: You must select a Y variable and a X variable/grouping variable to p
                     default: ""
                 })
             },
+            title: {
+                el: new input(config, {
+                    no: "specify_a_title",
+                    label: localization.en.specify_a_title,
+                    placeholder: "Chart title",
+                    allow_spaces:true,
+                    extraction: "NoPrefix|UseComma"
+            })},
+            x_title: {            
+                el: new input(config, {
+                    no: 'x_title',
+                    label: localization.en.x_title,
+                    placeholder: "X Axis",
+                    allow_spaces:true,
+                    extraction: "NoPrefix|UseComma"
+            })},
+            y_title: {
+                el: new input(config, {
+                    no: 'y_title',
+                    label: localization.en.y_title,
+                    placeholder: "Y Axis",
+                    allow_spaces:true,
+                    extraction: "NoPrefix|UseComma"
+            })},
+            fill1: {
+                el: new colorInput(config, {
+                    no: 'fill1',
+                    label: localization.en.fill1,
+                    placeholder: "#727272",
+                    allow_spaces:true,
+                    type: "character",
+                    extraction: "TextAsIs",
+                    value: "#727272"
+                })},
+            dropna: {
+                el: new checkbox(config, { 
+                    label: localization.en.dropna, 
+                    no: "dropna", 
+                    extraction: "Boolean" 
+                })},
+                        
         }
         const tab1 = {
             state: "active",
@@ -274,38 +315,11 @@ cat("Error: You must select a Y variable and a X variable/grouping variable to p
         var opts = new optionsVar(config, {
             no: "barchart_options",
             content: [
-                new input(config, {
-                    no: "specify_a_title",
-                    label: localization.en.specify_a_title,
-                    placeholder: "Chart title",
-                    allow_spaces:true,
-                    extraction: "NoPrefix|UseComma"
-                }),
-                new input(config, {
-                    no: 'x_title',
-                    label: localization.en.x_title,
-                    placeholder: "X Axis",
-                    allow_spaces:true,
-                    extraction: "NoPrefix|UseComma"
-                }),
-                new input(config, {
-                    no: 'y_title',
-                    label: localization.en.y_title,
-                    placeholder: "Y Axis",
-                    allow_spaces:true,
-                    extraction: "NoPrefix|UseComma"
-                }),
-               new colorInput(config, {
-                        no: 'fill1',
-                        label: localization.en.fill1,
-                        placeholder: "#727272",
-                        allow_spaces:true,
-                        type: "character",
-                        extraction: "TextAsIs",
-                        value: "#727272"
-                    }),
-                new checkbox(config, { label: localization.en.dropna, no: "dropna", extraction: "Boolean" }),
-                
+                objects.title.el,
+                objects.x_title.el,
+                objects.y_title.el,
+                objects.fill1.el,
+                objects.dropna.el
             ]
         })
         var Facets = {

--- a/contourPlot.js
+++ b/contourPlot.js
@@ -151,32 +151,32 @@ ggplot(data={{dataset.name}}, aes({{selected.x[0] | safe}}{{selected.y[0] | safe
                     default: ""
                 })
             },
-        }
-        var opts = new optionsVar(config, {
-            no: "Contour_plot_options",
-            content: [
-                new input(config, {
+            title: {
+                el: new input(config, {
                     no: 'specify_a_title',
                     label: localization.en.specify_a_title,
                     placeholder: "Chart title",
                     allow_spaces:true,
                     extraction: "NoPrefix|UseComma"
-                }),
-                new input(config, {
+            })},
+            x_title: {
+                el: new input(config, {
                     no: 'x_title',
                     label: "X Axis Label",
                     placeholder: "X Axis",
                     allow_spaces:true,
                     extraction: "NoPrefix|UseComma"
-                }),
-                new input(config, {
+            })},
+            y_title: {
+                el: new input(config, {
                     no: 'y_title',
                     label: "Y Axis Label",
                     placeholder: "Y Axis",
                     allow_spaces:true,
                     extraction: "NoPrefix|UseComma"
-                }),
-                new colorInput(config, {
+            })},
+            color: {
+                el: new colorInput(config, {
                     no: 'color',
                     label: "Select a color (After color selection, click outside the control to apply)",
                     placeholder: "#727272",
@@ -184,7 +184,16 @@ ggplot(data={{dataset.name}}, aes({{selected.x[0] | safe}}{{selected.y[0] | safe
                     type: "character",
                     extraction: "TextAsIs",
                     value: "#727272"
-                })
+            })}
+
+        }
+        var opts = new optionsVar(config, {
+            no: "Contour_plot_options",
+            content: [
+                objects.title.el,
+                objects.x_title.el,
+                objects.y_title.el,
+                objects.color.el
             ]
         })
         var Facets = {

--- a/coxComb.js
+++ b/coxComb.js
@@ -231,31 +231,37 @@ ggplot(data={{dataset.name}}, aes({{if (options.selected.x[0] == "")}}x='', {{#e
                     default: ""
                 })
             },
-        }
-        var opts = new optionsVar(config, {
-            no: "frequency_chart_options",
-            content: [
-                new input(config, {
+            title: {
+                el: new input(config, {
                     no: 'title',
                     label: localization.en.specify_a_title,
                     placeholder: "Chart title",
                     allow_spaces:true,
                     extraction: "NoPrefix|UseComma"
-                }),
-                new input(config, {
+            })},
+            x_title: {
+                el: new input(config, {
                     no: 'x_title',
                     label: localization.en.x_title,
                     allow_spaces:true,
                     placeholder: "X Axis",
                     extraction: "NoPrefix|UseComma"
-                }),
-                new input(config, {
+            })},
+            y_title: {
+                el: new input(config, {
                     no: 'y_title',
                     allow_spaces:true,
                     label: localization.en.y_title,
                     placeholder: "Y Axis",
                     extraction: "NoPrefix|UseComma"
-                }),
+            })},            
+        }
+        var opts = new optionsVar(config, {
+            no: "frequency_chart_options",
+            content: [
+                objects.title.el,
+                objects.x_title.el,
+                objects.y_title.el
             ]
         })
         var Facets = {

--- a/density.js
+++ b/density.js
@@ -194,31 +194,37 @@ ggplot(data={{dataset.name}}, aes({{selected.x[0] | safe}}{{selected.y[0] | safe
                     default: ""
                 })
             },
-        }
-        var opts = new optionsVar(config, {
-            no: "density_chart_options",
-            content: [
-                new input(config, {
+            title: {
+                el: new input(config, {
                     no: 'title',
                     allow_spaces:true,
                     label: localization.en.specify_a_title,
                     placeholder: "Chart title",
                     extraction: "NoPrefix|UseComma"
-                }),
-                new input(config, {
+            })},
+            x_title: {
+                el: new input(config, {
                     no: 'x_title',
                     label: localization.en.x_title,
                     placeholder: "X Axis",
                     allow_spaces:true,
                     extraction: "NoPrefix|UseComma"
-                }),
-                new input(config, {
+            })},
+            y_title: {
+                el: new input(config, {
                     no: 'y_title',
                     label: localization.en.x_title,
                     placeholder: "Y Axis",
                     allow_spaces:true,
                     extraction: "NoPrefix|UseComma"
-                }),
+            })},            
+        }
+        var opts = new optionsVar(config, {
+            no: "density_chart_options",
+            content: [
+                objects.title.el,
+                objects.x_title.el,
+                objects.y_title.el,
                 objects.fillcolor.el,
             ]
         })

--- a/frequencyFactor.js
+++ b/frequencyFactor.js
@@ -204,31 +204,37 @@ ggplot(data={{dataset.name}}, aes({{selected.x[0] | safe}}{{selected.y[0] | safe
                     default: ""
                 })
             },
-        }
-          var opts = new optionsVar(config, {
-            no: "frequency_chart_options",
-            content: [
-                new input(config, {
+            title: {
+                el: new input(config, {
                     no: 'title',
                     label: localization.en.specify_a_title,
                     allow_spaces:true,
                     placeholder: "Chart title",
                     extraction: "NoPrefix|UseComma"
-                }),
-                new input(config, {
+            })},
+            x_title: {
+                el: new input(config, {
                     no: 'x_title',
                     allow_spaces:true,
                     label: localization.en.x_title,
                     placeholder: "X Axis",
                     extraction: "NoPrefix|UseComma"
-                }),
-                new input(config, {
+            })},
+            y_title: {
+                el: new input(config, {
                     no: 'y_title',
                     allow_spaces:true,
                     label: localization.en.y_title,
                     placeholder: "Y Axis",
                     extraction: "NoPrefix|UseComma"
-                }),
+            })},            
+        }
+          var opts = new optionsVar(config, {
+            no: "frequency_chart_options",
+            content: [
+                objects.title.el,
+                objects.x_title.el,
+                objects.y_title.el
             ]
         })
         var Facets = {

--- a/histogram.js
+++ b/histogram.js
@@ -207,31 +207,37 @@ ggplot(data={{dataset.name}}, aes({{selected.x[0] | safe}})) +
                     default: ""
                 })
             },
-        }
-        var opts = new optionsVar(config, {
-            no: "histogram_options",
-            content: [
-                new input(config, {
+            title: {
+                el: new input(config, {
                     no: 'title',
                     allow_spaces:true,
                     label: localization.en.specify_a_title,
                     placeholder: "Chart title",
                     extraction: "NoPrefix|UseComma"
-                }),
-                new input(config, {
+            })},
+            x_title: {
+                el: new input(config, {
                     no: 'x_title',
                     allow_spaces:true,
                     label: localization.en.x_title,
                     placeholder: "X Axis",
                     extraction: "NoPrefix|UseComma"
-                }),
-                new input(config, {
+            })},
+            y_title: {
+                el: new input(config, {
                     no: 'y_title',
                     allow_spaces:true,
                     label: localization.en.y_title,
                     placeholder: "Y Axis",
                     extraction: "NoPrefix|UseComma"
-                }),
+            })},            
+        }
+        var opts = new optionsVar(config, {
+            no: "histogram_options",
+            content: [
+                objects.title.el,
+                objects.x_title.el,
+                objects.y_title.el,
                 objects.barcolor.el,
                 objects.normalCurveColor.el,
                 objects.rugPlot.el

--- a/pieChart.js
+++ b/pieChart.js
@@ -213,31 +213,37 @@ ggplot(data={{dataset.name}}, aes({{if (options.selected.x[0] == "")}}x='', {{#e
                     default: ""
                 })
             },
-        }
-        var opts = new optionsVar(config, {
-            no: "frequency_chart_options",
-            content: [
-                new input(config, {
+            title: {
+                el: new input(config, {
                     no: "specify_a_title",
                     label: localization.en.specify_a_title,
                     allow_spaces:true,
                     placeholder: "Chart title",
                     extraction: "NoPrefix|UseComma"
-                }),
-                new input(config, {
+            })},
+            x_title: {
+                el: new input(config, {
                     no: 'x_title',
                     label: localization.en.x_title,
                     allow_spaces:true,
                     placeholder: "X Axis",
                     extraction: "NoPrefix|UseComma"
-                }),
-                new input(config, {
+            })},
+            y_title: {
+                el: new input(config, {
                     no: 'y_title',
                     label: localization.en.y_title,
                     allow_spaces:true,
                     placeholder: "Y Axis",
                     extraction: "NoPrefix|UseComma"
-                }),
+            })},            
+        }
+        var opts = new optionsVar(config, {
+            no: "frequency_chart_options",
+            content: [
+                objects.title.el,
+                objects.x_title.el,
+                objects.y_title.el
             ]
         })
         var Facets = {

--- a/plotOfMeans.js
+++ b/plotOfMeans.js
@@ -264,32 +264,32 @@ ggplot(data=temp, aes({{ selected.x[0] | safe }}{{ selected.y[0] | safe }}{{ sel
                     allow_spaces:true,
                     placeholder: "Chart title",
                     extraction: "NoPrefix|UseComma"
-            })},
-            x_title: {
+                })},	
+			x_title: {
                 el: new input(config, {
                     no: 'x_title',
                     allow_spaces:true,
                     label: "X Axis Label",
                     placeholder: "X Axis",
                     extraction: "NoPrefix|UseComma"
-            })},
-            y_title: {
+                })},
+			y_title: {
                 el: new input(config, {
                     no: 'y_title',
                     allow_spaces:true,
                     label: "Y Axis Label",
                     placeholder: "Y Axis",
                     extraction: "NoPrefix|UseComma"
-            })}           
+                })},
         }
-        var opts = new optionsVar(config, {
+        var opts = {el: new optionsVar(config, {
             no: "plotOfMeans_options",
             content: [
                 objects.title.el,
-                objects.x_title.el,
-                objects.y_title.el
+                    objects.x_title.el,
+                    objects.y_title.el,
             ]
-        })
+        })};
         var Facets = {
             el: new optionsVar(config, {
                 no: "Facets",
@@ -305,7 +305,7 @@ ggplot(data=temp, aes({{ selected.x[0] | safe }}{{ selected.y[0] | safe }}{{ sel
         const content = {
             left: [objects.content_var.el.content],
             right: [objects.y.el.content, objects.x.el.content, objects.fill.el.content, objects.checkbox.el.content, objects.alpha.el.content, objects.label1.el.content, objects.radiobuttonNo.el.content, objects.radiobuttonSe.el.content, objects.radiobuttonSd.el.content, objects.radiobuttonCi.el.content, objects.confidenceInterval.el.content,],
-            bottom: [opts.content, Facets.el.content],
+            bottom: [opts.el.content, Facets.el.content],
             nav: {
                 name: localization.en.navigation,
                 icon: "icon-line-dot-chart",
@@ -332,15 +332,18 @@ ggplot(data=temp, aes({{ selected.x[0] | safe }}{{ selected.y[0] | safe }}{{ sel
                     flip: instance.objects.checkbox.el.getVal() ? instance.objects.checkbox.r : "",
                     alpha: instance.objects.alpha.el.getVal(),
                     confidenceInterval: instance.objects.confidenceInterval.el.getVal(),
-                    title: instance.opts.config.content[0].getVal() === "" ? "" : `ggtitle("${instance.opts.config.content[0].getVal()}") + `,
                     Facetrow: instance.objects.Facetrow.el.getVal(),
                     Facetcolumn: instance.objects.Facetcolumn.el.getVal(),
                     Facetwrap: instance.objects.Facetwrap.el.getVal(),
                     Facetscale: instance.objects.Facetscale.el.getVal(),
                 }
             }
-            code_vars.selected["x_label"] = instance.opts.config.content[1].getVal() === "" ? code_vars.selected.x[3] : instance.opts.config.content[1].getVal()
-            code_vars.selected["y_label"] = instance.opts.config.content[2].getVal() === "" ? code_vars.selected.y[3] : instance.opts.config.content[2].getVal()
+            //Aaron: please retain the comments below, I may want to reuse thus
+           // code_vars.selected["x_label"] = instance.opts.config.content[1].getVal() === "" ? code_vars.selected.x[3] : instance.opts.config.content[1].getVal()
+           // code_vars.selected["y_label"] = instance.opts.config.content[2].getVal() === "" ? code_vars.selected.y[3] : instance.opts.config.content[2].getVal()
+           code_vars.selected["title"] = instance.objects.title.el.getVal() === "" ? "" : `ggtitle("${instance.objects.title.el.getVal()}") + `
+           code_vars.selected["x_label"] = instance.objects.x_title.el.getVal() === "" ? code_vars.selected.x[3] : instance.objects.x_title.el.getVal()
+           code_vars.selected["y_label"] = instance.objects.y_title.el.getVal() === "" ? code_vars.selected.y[3] : instance.objects.y_title.el.getVal()
             if (!(code_vars.selected.Facetcolumn.length == 0 && code_vars.selected.Facetrow.length == 0 && code_vars.selected.Facetwrap.length == 0)) {
                 code_vars.selected.tempFacets = stringWithFacetsForPlotOfMeans(code_vars.selected.Facetrow, code_vars.selected.Facetcolumn, code_vars.selected.Facetwrap)
             }

--- a/plotOfMeans.js
+++ b/plotOfMeans.js
@@ -257,31 +257,37 @@ ggplot(data=temp, aes({{ selected.x[0] | safe }}{{ selected.y[0] | safe }}{{ sel
                     default: ""
                 })
             },
-        }
-        var opts = new optionsVar(config, {
-            no: "plotOfMeans_options",
-            content: [
-                new input(config, {
+            title: {
+                el: new input(config, {
                     no: 'title',
                     label: "Chart Title",
                     allow_spaces:true,
                     placeholder: "Chart title",
                     extraction: "NoPrefix|UseComma"
-                }),
-                new input(config, {
+            })},
+            x_title: {
+                el: new input(config, {
                     no: 'x_title',
                     allow_spaces:true,
                     label: "X Axis Label",
                     placeholder: "X Axis",
                     extraction: "NoPrefix|UseComma"
-                }),
-                new input(config, {
+            })},
+            y_title: {
+                el: new input(config, {
                     no: 'y_title',
                     allow_spaces:true,
                     label: "Y Axis Label",
                     placeholder: "Y Axis",
                     extraction: "NoPrefix|UseComma"
-                })
+            })}           
+        }
+        var opts = new optionsVar(config, {
+            no: "plotOfMeans_options",
+            content: [
+                objects.title.el,
+                objects.x_title.el,
+                objects.y_title.el
             ]
         })
         var Facets = {

--- a/ppPlots.js
+++ b/ppPlots.js
@@ -202,39 +202,48 @@ ggplot(data={{dataset.name}}, aes({{selected.x[0] | safe}}{{selected.y[0] | safe
                     default: ""
                 })
             },
-        }
-        var opts = new optionsVar(config, {
-            no: "frequency_chart_options",
-            content: [
-                new input(config, {
+            title: {
+                el: new input(config, {
                     no: 'title',
                     allow_spaces:true,
                     label: localization.en.title,
                     placeholder: "Chart title",
                     extraction: "NoPrefix|UseComma"
-                }),
-                new input(config, {
+            })},
+            x_title: {
+                el: new input(config, {
                     no: 'x_title',
                     allow_spaces:true,
                     label: localization.en.x_title,
                     placeholder: "X Axis",
                     extraction: "NoPrefix|UseComma"
-                }),
-                new input(config, {
+            })},
+            y_title: {
+                el: new input(config, {
                     no: 'y_title',
                     allow_spaces:true,
                     label: localization.en.y_title,
                     placeholder: "Y Axis",
                     extraction: "NoPrefix|UseComma"
-                }),
-                objects.distribution.el,
-                objects.label1.el,
-                new input(config, {
+            })},   
+            dparams: {
+                el: new input(config, {
                     no: 'dparams',
                     label: localization.en.dparams,
                     allow_spaces:true,
                     extraction: "NoPrefix|UseComma"
-                }),
+                })},                
+                     
+        }
+        var opts = new optionsVar(config, {
+            no: "frequency_chart_options",
+            content: [
+                objects.title.el,
+                objects.x_title.el,
+                objects.y_title.el,
+                objects.distribution.el,
+                objects.label1.el,
+                objects.dparams.el,
             ]
         })
         var Facets = {

--- a/qqPlots.js
+++ b/qqPlots.js
@@ -213,39 +213,47 @@ ggplot(data={{dataset.name}}, aes({{selected.x[0] | safe}}{{selected.y[0] | safe
                     default: ""
                 })
             },
-        }
-        var opts = new optionsVar(config, {
-            no: "frequency_chart_options",
-            content: [
-                new input(config, {
+            title: {
+                el: new input(config, {
                     no: "specify_a_title",
                     label: localization.en.specify_a_title,
                     allow_spaces:true,
                     placeholder: "Chart title",
                     extraction: "NoPrefix|UseComma"
-                }),
-                new input(config, {
+            })},
+            x_title: {
+                el: new input(config, {
                     no: 'x_title',
                     label: localization.en.x_title,
                     placeholder: "X Axis",
                     allow_spaces:true,
                     extraction: "NoPrefix|UseComma"
-                }),
-                new input(config, {
+            })},
+            y_title: {
+                el: new input(config, {
                     no: 'y_title',
                     allow_spaces:true,
                     label: localization.en.y_title,
                     placeholder: "Y Axis",
                     extraction: "NoPrefix|UseComma"
-                }),
-                objects.distribution.el,
-                objects.label1.el,
-                new input(config, {
+            })},   
+            dparams: {
+                el: new input(config, {
                     no: 'dparams',
                     allow_spaces:true,
                     label: localization.en.dparams,
                     extraction: "NoPrefix|UseComma"
-                }),
+            })}         
+        }
+        var opts = new optionsVar(config, {
+            no: "frequency_chart_options",
+            content: [
+                objects.title.el,
+                objects.x_title.el,
+                objects.y_title.el,
+                objects.distribution.el,
+                objects.label1.el,
+                objects.dparams.el
             ]
         })
         var Facets = {

--- a/stripChart.js
+++ b/stripChart.js
@@ -208,31 +208,37 @@ ggplot(data={{dataset.name}}, aes({{selected.x[0] | safe}}{{selected.y[0] | safe
                     default: ""
                 })
             },
-        }
-        var opts = new optionsVar(config, {
-            no: "Stripchart_options",
-            content: [
-                new input(config, {
+            title: {
+                el: new input(config, {
                     no: 'specify_a_title',
                     allow_spaces:true,
                     label: localization.en.specify_a_title,
                     placeholder: "Chart title",
                     extraction: "NoPrefix|UseComma"
-                }),
-                new input(config, {
+            })},
+            x_title: {
+                el: new input(config, {
                     no: 'x_title',
                     label: localization.en.x_title,
                     allow_spaces:true,
                     placeholder: "X Axis",
                     extraction: "NoPrefix|UseComma"
-                }),
-                new input(config, {
+            })},
+            y_title: {            
+                el: new input(config, {
                     no: 'y_title',
                     label: localization.en.y_title,
                     allow_spaces:true,
                     placeholder: "Y Axis",
                     extraction: "NoPrefix|UseComma"
-                })
+            })},
+        }
+        var opts = new optionsVar(config, {
+            no: "Stripchart_options",
+            content: [
+                objects.title.el,
+                objects.x_title.el,
+                objects.y_title.el
             ]
         })
         var Facets = {


### PR DESCRIPTION
Say histogram executed first time from the top level menu. Then again execute from the top level menu, you see the plot titles (title, x_title, y_title) filled from the previous execution.

Plot-of-means does not execute when opened from history. We need to fix that.